### PR TITLE
Read only_txt and run script

### DIFF
--- a/RUN_SCRIPTS_README.md
+++ b/RUN_SCRIPTS_README.md
@@ -1,0 +1,130 @@
+# RAFT运行脚本说明
+
+本项目提供了多个运行脚本来处理文本文件并生成合成数据集。
+
+## 脚本文件说明
+
+1. **run_raft.py** - Python主运行脚本，提供批量处理功能
+2. **run.sh** - Shell包装脚本，提供简化的命令行接口
+3. **example_usage.sh** - 使用示例脚本
+
+## 快速开始
+
+### 1. 安装依赖
+
+```bash
+pip install -r requirements.txt
+```
+
+### 2. 配置环境
+
+创建 `.env` 文件并配置API密钥：
+
+```bash
+# OpenAI API配置
+OPENAI_API_KEY=your_api_key_here
+OPENAI_API_BASE=your_api_base_url  # 可选
+
+# 其他模型配置
+DEEPSEEK_API_KEY=your_deepseek_key
+```
+
+### 3. 运行脚本
+
+#### 处理所有文本文件
+```bash
+./run.sh
+```
+
+#### 处理单个文件
+```bash
+./run.sh -f data/example.txt
+```
+
+#### 使用Python脚本（更多选项）
+```bash
+python3 run_raft.py --input data --questions 5 --chunk-size 1024
+```
+
+## 参数说明
+
+### run.sh 参数
+
+- `-h, --help` - 显示帮助信息
+- `-i, --input DIR` - 输入目录或文件（默认: data）
+- `-o, --output DIR` - 输出基础目录（默认: outputs）
+- `-f, --file FILE` - 处理单个文件
+- `-q, --questions NUM` - 每个块的问题数量（默认: 2）
+- `-d, --distractors NUM` - 干扰项数量（默认: 3）
+- `-c, --chunk-size SIZE` - 文本块大小（默认: 512）
+- `-m, --model MODEL` - 补全模型（默认: deepseek-r1-250120）
+
+### run_raft.py 参数
+
+```
+--input              输入文件或目录路径
+--output-base        输出基础目录
+--output-format      输出格式 (hf/completion/chat)
+--distractors        干扰项数量
+--p                  采样概率
+--doctype            文档类型 (txt/pdf/json/api)
+--chunk-size         文本块大小
+--questions          每个块生成的问题数量
+--completion-model   补全模型
+--system-prompt-key  系统提示词键 (gpt/llama/deepseek/deepseek-v2)
+--embedding-model    嵌入模型
+--single-file        处理单个文件
+```
+
+## 输出格式
+
+处理结果将保存在输出目录中，结构如下：
+
+```
+outputs/
+├── 文件名_20240125_143022/
+│   ├── train_dataset.jsonl
+│   └── metadata.json
+├── processing_log_20240125_143022.json
+└── ...
+```
+
+## 支持的文件类型
+
+- `.txt` - 纯文本文件
+- `.md` - Markdown文件
+- `.pdf` - PDF文档（需要指定 --doctype pdf）
+- `.json` - JSON文件（需要指定 --doctype json）
+
+## 模型支持
+
+### 补全模型
+- deepseek-r1-250120（默认）
+- qwen-plus
+- gpt-3.5-turbo
+- gpt-4
+
+### 嵌入模型
+- text-embedding-v2
+- doubao-embedding-large-text-250515
+
+## 使用示例
+
+查看更多使用示例：
+```bash
+./example_usage.sh
+```
+
+## 注意事项
+
+1. 确保API密钥已正确配置
+2. 大文件处理可能需要较长时间
+3. 输出文件会自动按时间戳命名，避免覆盖
+4. 处理日志会保存在输出目录中
+
+## 故障排除
+
+1. **找不到Python3**: 确保已安装Python 3.7+
+2. **缺少依赖**: 运行 `pip install -r requirements.txt`
+3. **API错误**: 检查.env文件中的API密钥配置
+4. **内存不足**: 减小chunk-size参数值

--- a/example_usage.sh
+++ b/example_usage.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+echo "RAFT运行脚本使用示例"
+echo "===================="
+echo ""
+
+echo "1. 处理data目录下的所有文本文件（使用默认参数）:"
+echo "   ./run.sh"
+echo ""
+
+echo "2. 处理单个文件:"
+echo "   ./run.sh -f data/97平板显示综述_朱昌昌_llm_correct.md"
+echo ""
+
+echo "3. 处理特定目录，生成更多问题:"
+echo "   ./run.sh -i data -q 5 -d 4"
+echo ""
+
+echo "4. 使用不同的模型:"
+echo "   ./run.sh -m qwen-plus"
+echo ""
+
+echo "5. 直接使用Python脚本（更多控制选项）:"
+echo "   python3 run_raft.py --input data --questions 3 --chunk-size 1024"
+echo ""
+
+echo "6. 处理单个文件的Python命令:"
+echo "   python3 run_raft.py --single-file data/97平板显示综述_朱昌昌_llm_correct.md"
+echo ""
+
+echo "7. 查看帮助:"
+echo "   ./run.sh -h"
+echo "   python3 run_raft.py --help"
+echo ""
+
+echo "注意事项:"
+echo "- 确保已安装所需的Python依赖（查看requirements.txt）"
+echo "- 确保已配置API密钥（在.env文件中）"
+echo "- 输出将保存在outputs目录下，按文件名和时间戳组织"

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# RAFT运行脚本
+# 用于处理文本文件并生成合成数据集
+
+echo "==================================="
+echo "RAFT 文本处理运行脚本"
+echo "==================================="
+
+# 设置默认参数
+INPUT_DIR="data"
+OUTPUT_BASE="outputs"
+OUTPUT_FORMAT="completion"
+DISTRACTORS=3
+P=1.0
+DOCTYPE="txt"
+CHUNK_SIZE=512
+QUESTIONS=2
+COMPLETION_MODEL="deepseek-r1-250120"
+SYSTEM_PROMPT="deepseek-v2"
+
+# 显示使用说明
+show_help() {
+    echo "使用方法:"
+    echo "  ./run.sh [选项]"
+    echo ""
+    echo "选项:"
+    echo "  -h, --help              显示帮助信息"
+    echo "  -i, --input DIR         输入目录或文件 (默认: data)"
+    echo "  -o, --output DIR        输出基础目录 (默认: outputs)"
+    echo "  -f, --file FILE         处理单个文件"
+    echo "  -q, --questions NUM     每个块的问题数量 (默认: 2)"
+    echo "  -d, --distractors NUM   干扰项数量 (默认: 3)"
+    echo "  -c, --chunk-size SIZE   文本块大小 (默认: 512)"
+    echo "  -m, --model MODEL       补全模型 (默认: deepseek-r1-250120)"
+    echo ""
+    echo "示例:"
+    echo "  ./run.sh                           # 处理data目录下的所有文本文件"
+    echo "  ./run.sh -f data/example.txt      # 处理单个文件"
+    echo "  ./run.sh -i custom_data -q 5      # 处理custom_data目录，每块生成5个问题"
+}
+
+# 解析命令行参数
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        -i|--input)
+            INPUT_DIR="$2"
+            shift 2
+            ;;
+        -o|--output)
+            OUTPUT_BASE="$2"
+            shift 2
+            ;;
+        -f|--file)
+            SINGLE_FILE="$2"
+            shift 2
+            ;;
+        -q|--questions)
+            QUESTIONS="$2"
+            shift 2
+            ;;
+        -d|--distractors)
+            DISTRACTORS="$2"
+            shift 2
+            ;;
+        -c|--chunk-size)
+            CHUNK_SIZE="$2"
+            shift 2
+            ;;
+        -m|--model)
+            COMPLETION_MODEL="$2"
+            shift 2
+            ;;
+        *)
+            echo "未知选项: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# 检查Python环境
+if ! command -v python3 &> /dev/null; then
+    echo "错误: 未找到Python3"
+    exit 1
+fi
+
+# 检查必要的文件
+if [ ! -f "raft.py" ]; then
+    echo "错误: 未找到raft.py文件"
+    exit 1
+fi
+
+if [ ! -f "run_raft.py" ]; then
+    echo "错误: 未找到run_raft.py文件"
+    exit 1
+fi
+
+# 构建命令
+CMD="python3 run_raft.py"
+CMD="$CMD --input \"$INPUT_DIR\""
+CMD="$CMD --output-base \"$OUTPUT_BASE\""
+CMD="$CMD --output-format \"$OUTPUT_FORMAT\""
+CMD="$CMD --distractors $DISTRACTORS"
+CMD="$CMD --p $P"
+CMD="$CMD --doctype \"$DOCTYPE\""
+CMD="$CMD --chunk-size $CHUNK_SIZE"
+CMD="$CMD --questions $QUESTIONS"
+CMD="$CMD --completion-model \"$COMPLETION_MODEL\""
+CMD="$CMD --system-prompt-key \"$SYSTEM_PROMPT\""
+
+# 如果指定了单个文件
+if [ ! -z "$SINGLE_FILE" ]; then
+    CMD="$CMD --single-file \"$SINGLE_FILE\""
+fi
+
+# 显示运行信息
+echo ""
+echo "运行参数:"
+echo "  输入: ${SINGLE_FILE:-$INPUT_DIR}"
+echo "  输出目录: $OUTPUT_BASE"
+echo "  问题数量: $QUESTIONS"
+echo "  干扰项: $DISTRACTORS"
+echo "  块大小: $CHUNK_SIZE"
+echo "  模型: $COMPLETION_MODEL"
+echo ""
+
+# 确认运行
+read -p "是否开始处理? (y/n) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "已取消"
+    exit 0
+fi
+
+# 运行命令
+echo "开始处理..."
+eval $CMD
+
+echo ""
+echo "处理完成!"

--- a/run_raft.py
+++ b/run_raft.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+RAFT运行脚本
+用于处理文本文件并生成合成数据集
+"""
+
+import os
+import sys
+import subprocess
+import argparse
+from pathlib import Path
+import json
+from datetime import datetime
+
+def run_raft_command(datapath, output_dir, **kwargs):
+    """运行单个RAFT命令"""
+    cmd = [
+        "python", "raft.py",
+        "--datapath", str(datapath),
+        "--output", str(output_dir),
+    ]
+    
+    # 添加其他参数
+    for key, value in kwargs.items():
+        if value is not None:
+            cmd.extend([f"--{key.replace('_', '-')}", str(value)])
+    
+    print(f"\n运行命令: {' '.join(cmd)}")
+    
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        print(f"✓ 成功处理: {datapath}")
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"✗ 处理失败: {datapath}")
+        print(f"错误信息: {e.stderr}")
+        return False
+
+def find_text_files(directory):
+    """查找目录中的所有文本文件"""
+    text_extensions = ['.txt', '.md']
+    files = []
+    
+    if os.path.isfile(directory):
+        return [Path(directory)]
+    
+    for ext in text_extensions:
+        files.extend(Path(directory).glob(f"**/*{ext}"))
+    
+    return sorted(files)
+
+def main():
+    parser = argparse.ArgumentParser(description="RAFT批量处理脚本")
+    parser.add_argument("--input", type=str, default="data", 
+                       help="输入文件或目录路径")
+    parser.add_argument("--output-base", type=str, default="outputs", 
+                       help="输出基础目录")
+    parser.add_argument("--output-format", type=str, default="completion",
+                       choices=["hf", "completion", "chat"],
+                       help="输出格式")
+    parser.add_argument("--distractors", type=int, default=3,
+                       help="干扰项数量")
+    parser.add_argument("--p", type=float, default=1.0,
+                       help="采样概率")
+    parser.add_argument("--doctype", type=str, default="txt",
+                       choices=["api", "pdf", "json", "txt"],
+                       help="文档类型")
+    parser.add_argument("--chunk-size", type=int, default=512,
+                       help="文本块大小")
+    parser.add_argument("--questions", type=int, default=2,
+                       help="每个块生成的问题数量")
+    parser.add_argument("--completion-model", type=str, default="deepseek-r1-250120",
+                       help="补全模型")
+    parser.add_argument("--system-prompt-key", type=str, default="deepseek-v2",
+                       choices=["gpt", "llama", "deepseek", "deepseek-v2"],
+                       help="系统提示词键")
+    parser.add_argument("--embedding-model", type=str, default=None,
+                       help="嵌入模型")
+    parser.add_argument("--single-file", type=str, default=None,
+                       help="处理单个文件")
+    
+    args = parser.parse_args()
+    
+    # 确定要处理的文件
+    if args.single_file:
+        files_to_process = [Path(args.single_file)]
+    else:
+        files_to_process = find_text_files(args.input)
+    
+    if not files_to_process:
+        print(f"未找到可处理的文件在: {args.input}")
+        return
+    
+    print(f"找到 {len(files_to_process)} 个文件待处理")
+    
+    # 创建输出基础目录
+    os.makedirs(args.output_base, exist_ok=True)
+    
+    # 处理统计
+    success_count = 0
+    failed_files = []
+    
+    # 处理每个文件
+    for idx, file_path in enumerate(files_to_process, 1):
+        print(f"\n[{idx}/{len(files_to_process)}] 处理文件: {file_path}")
+        
+        # 生成输出目录名
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        file_stem = file_path.stem.replace(" ", "_")[:50]  # 限制文件名长度
+        output_dir = Path(args.output_base) / f"{file_stem}_{timestamp}"
+        
+        # 运行RAFT
+        success = run_raft_command(
+            datapath=file_path,
+            output_dir=output_dir,
+            output_format=args.output_format,
+            distractors=args.distractors,
+            p=args.p,
+            doctype=args.doctype,
+            chunk_size=args.chunk_size,
+            questions=args.questions,
+            completion_model=args.completion_model,
+            system_prompt_key=args.system_prompt_key,
+            embedding_model=args.embedding_model
+        )
+        
+        if success:
+            success_count += 1
+        else:
+            failed_files.append(str(file_path))
+    
+    # 打印总结
+    print("\n" + "="*50)
+    print("处理完成!")
+    print(f"成功: {success_count}/{len(files_to_process)}")
+    
+    if failed_files:
+        print(f"\n失败的文件:")
+        for f in failed_files:
+            print(f"  - {f}")
+    
+    # 保存处理日志
+    log_file = Path(args.output_base) / f"processing_log_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+    log_data = {
+        "timestamp": datetime.now().isoformat(),
+        "total_files": len(files_to_process),
+        "success_count": success_count,
+        "failed_files": failed_files,
+        "parameters": vars(args)
+    }
+    
+    with open(log_file, 'w', encoding='utf-8') as f:
+        json.dump(log_data, f, ensure_ascii=False, indent=2)
+    
+    print(f"\n处理日志已保存到: {log_file}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add comprehensive run scripts to facilitate text file processing and synthetic data generation for the RAFT project.

The initial request was to read a specific file ('only_txt') and create a run script. Since 'only_txt' was not found, this PR provides a general, robust, and well-documented set of scripts (`run_raft.py`, `run.sh`, `example_usage.sh`, `RUN_SCRIPTS_README.md`) to process text files within the project's `data` directory using the RAFT pipeline, addressing the underlying need for project execution.

---
<a href="https://cursor.com/background-agent?bcId=bc-f36cc2e4-a294-4bc8-8358-6a691a6bfc89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f36cc2e4-a294-4bc8-8358-6a691a6bfc89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

